### PR TITLE
Add: All details areas clear after selecting new item on the dropdown menu

### DIFF
--- a/scripts/attractions/AttractionComponent.js
+++ b/scripts/attractions/AttractionComponent.js
@@ -15,3 +15,12 @@ export const attractionDetailsComponent = (object) => {
         <li>Description: ${object.description}</li>
     </ul>`
 }
+
+const clearComponent = () => {
+    return ``
+}
+
+export const attractionClear = () => {
+    const clearElement = document.querySelector("#details-container__attraction")
+    clearElement.innerHTML = clearComponent()
+}

--- a/scripts/attractions/AttractionComponent.js
+++ b/scripts/attractions/AttractionComponent.js
@@ -16,10 +16,12 @@ export const attractionDetailsComponent = (object) => {
     </ul>`
 }
 
+// Sets details field to an empty space "resetting" that area
 const clearComponent = () => {
     return ``
 }
 
+// Sets HTML on the DOM to the empty string in clearComponent
 export const attractionClear = () => {
     const clearElement = document.querySelector("#details-container__attraction")
     clearElement.innerHTML = clearComponent()

--- a/scripts/attractions/AttractionProvider.js
+++ b/scripts/attractions/AttractionProvider.js
@@ -1,4 +1,4 @@
-import { attractionComponent, attractionDetailsComponent } from "./AttractionComponent.js"
+import { attractionComponent, attractionDetailsComponent, attractionClear } from "./AttractionComponent.js"
 
 let allAttractions = [];
 
@@ -56,6 +56,7 @@ const showAttraction = (eat) => {
             const attractionArray = useAttractions().filter(oneAttraction => {
                 if(oneAttraction.id === eat){
                     currentAttraction = oneAttraction
+                    attractionClear()
                     return oneAttraction
                 }
             })

--- a/scripts/eateries/EateryComponent.js
+++ b/scripts/eateries/EateryComponent.js
@@ -16,10 +16,12 @@ export const eatDetailsComponent = (object) => {
     </ul>`
 }
 
+// Sets details field to an empty space "resetting" that area
 const clearComponent = () => {
     return ``
 }
 
+// Sets HTML on the DOM to the empty string in clearComponent
 export const eatClear = () => {
     const clearElement = document.querySelector("#details-container__eatery")
     clearElement.innerHTML = clearComponent()

--- a/scripts/eateries/EateryComponent.js
+++ b/scripts/eateries/EateryComponent.js
@@ -15,3 +15,12 @@ export const eatDetailsComponent = (object) => {
         <li>Description: ${object.description}</li>
     </ul>`
 }
+
+const clearComponent = () => {
+    return ``
+}
+
+export const eatClear = () => {
+    const clearElement = document.querySelector("#details-container__eatery")
+    clearElement.innerHTML = clearComponent()
+}

--- a/scripts/eateries/EateryProvider.js
+++ b/scripts/eateries/EateryProvider.js
@@ -1,4 +1,4 @@
-import { eatComponent, eatDetailsComponent } from "./EateryComponent.js"
+import { eatComponent, eatDetailsComponent, eatClear } from "./EateryComponent.js"
 let allEateries = []
 
 const useEateries = () => [...allEateries]
@@ -45,6 +45,7 @@ export const eateryListener = () => {
             const eateryValue = parseInt(event.target.value)
             console.log(eateryValue)
             showEatery(eateryValue)
+            eatClear()
         }
         })
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,13 +1,8 @@
-import { weatherList } from "./weather/WeatherProvider.js"
-
-
-// showWeatherList();
-weatherList();
-
 import { populateEateries, eateryListener, eatDetails } from "./eateries/EateryProvider.js";
 import { populateAttractions, attractionListener, attractionDetails } from "./attractions/AttractionProvider.js";
 import { populateParks, parkListener, parkDetails} from "./parks/ParkProvider.js"
 import { saveListener } from "./saveButton.js";
+import { weatherList } from "./weather/WeatherProvider.js"
 
 
 populateAttractions();
@@ -21,3 +16,5 @@ saveListener();
 eatDetails();
 parkDetails();
 attractionDetails();
+// showWeatherList();
+weatherList();

--- a/scripts/parks/ParkProvider.js
+++ b/scripts/parks/ParkProvider.js
@@ -1,5 +1,5 @@
 import { settings } from "../Settings.js"
-import { parkComponent, parkDetailsComponent } from "./ParksComponent.js"
+import { parkComponent, parkDetailsComponent, parkClear } from "./ParksComponent.js"
 import { useWeatherCollection, weatherList} from "../weather/WeatherProvider.js"
 
 
@@ -79,10 +79,10 @@ const showPark = (park) => {
         const parkArray = useParks().filter(onePark => {
             if(onePark.id === park){
                 currentPark = onePark
-                console.log(currentPark.description)
+                // console.log(currentPark.description)
                 lat = onePark.latitude
                 long= onePark.longitude
-            
+                parkClear()
                 return onePark
             }
         })

--- a/scripts/parks/ParksComponent.js
+++ b/scripts/parks/ParksComponent.js
@@ -16,3 +16,12 @@ export const parkDetailsComponent = (object) => {
     </ul>
     `
 }
+
+const clearComponent = () => {
+    return ``
+}
+
+export const parkClear = () => {
+    const clearElement = document.querySelector("#details-container__park")
+    clearElement.innerHTML = clearComponent()
+}

--- a/scripts/parks/ParksComponent.js
+++ b/scripts/parks/ParksComponent.js
@@ -17,10 +17,12 @@ export const parkDetailsComponent = (object) => {
     `
 }
 
+// Sets details field to an empty space "resetting" that area
 const clearComponent = () => {
     return ``
 }
 
+// Sets HTML on the DOM to the empty string in clearComponent
 export const parkClear = () => {
     const clearElement = document.querySelector("#details-container__park")
     clearElement.innerHTML = clearComponent()

--- a/styles/main.css
+++ b/styles/main.css
@@ -92,14 +92,14 @@ background-size:cover;
     margin-top: 10px;
     justify-content: center;
     height: 500px;
-    border: 5px red solid;
+    /* border: 5px red solid; */
 }
 
 #details-container__park, #details-container__eatery, #details-container__attraction {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    border: 5px green solid;
+    /* border: 5px green solid; */
     width: 100px;
 }
 


### PR DESCRIPTION
# Description

Added function that clears description fields when new item on the dropdown is selected.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
Select an item from all three drop down menus. Click details buttons. Select new items on all three dropdown menus. Details for previously selected items should disappear. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
